### PR TITLE
Adding support for Laravel 5.4

### DIFF
--- a/src/Yocmen/HtmlMinify/HtmlMinifyCompiler.php
+++ b/src/Yocmen/HtmlMinify/HtmlMinifyCompiler.php
@@ -15,24 +15,7 @@ class HtmlMinifyCompiler extends BladeCompiler
         // Add Minify to the list of compilers
         if ($this->_config['enabled'] === true) {
             $this->compilers[] = 'Minify';
-        }
-
-        // Set Blade contentTags and escapedContentTags
-		$this->setRawTags(
-            $this->_config['blade']['rawTags'][0],
-            $this->_config['blade']['rawTags'][1]
-        );
-		
-        $this->setContentTags(
-            $this->_config['blade']['contentTags'][0],
-            $this->_config['blade']['contentTags'][1]
-        );
-	
-        $this->setEscapedContentTags(
-            $this->_config['blade']['escapedContentTags'][0],
-            $this->_config['blade']['escapedContentTags'][1]
-        );
-		
+        }		
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -5,12 +5,4 @@
 
     // Turn on/off the comment stripping in the minified file
     'comment_stripping' => true,
-
-    // If you are using a javascript framework that conflicts
-    // with Blade's tags, you can change them here
-    'blade' => [
-		'rawTags' => ['{!!', '!!}'],
-        'contentTags' => ['{{', '}}'],
-        'escapedContentTags' => ['{{{', '}}}']
-    ]
 ];


### PR DESCRIPTION
Removing setting of:
- Blade raw tags
- Blade content tags
- Blade escaped content tags
In order to support Laravel 5.4 as these methods have been removed.